### PR TITLE
update apiVersion

### DIFF
--- a/projects/store-ui/.nodeshift/deployment.yml
+++ b/projects/store-ui/.nodeshift/deployment.yml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: apps.openshift.io/v1
 kind: Deployment
 metadata:
   annotations:


### PR DESCRIPTION
Failing to build and install install on RHPDS -  the apiVersoin should change for nodeshift to pick up as "apps.openshift.io/v1"